### PR TITLE
Use later sysctl config

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -2,6 +2,7 @@
 - name: Ensure IP forwarding is enabled
   ansible.posix.sysctl:
     name: "{{ item }}"
+    sysctl_file: /etc/sysctl.d/99-forwarding.conf
     value: '1'
     state: present
   loop: "{{ (['net.ipv6.conf.all.forwarding'] if wg_ipv6_enable else []) | union(


### PR DESCRIPTION
The default sysctl config file does work anymore on Debian 13 in some cases, we use another one